### PR TITLE
AssetManager fix

### DIFF
--- a/src/Asset/AssetManager.php
+++ b/src/Asset/AssetManager.php
@@ -258,8 +258,8 @@ class AssetManager
                 $baseUrl = $this->baseUrl;
             }
         } else {
-            $basePath = $this->aliases->get($bundle->basePath);
-            $baseUrl = $this->aliases->get($bundle->baseUrl);
+            $basePath = $bundle->basePath === null ? '' : $this->aliases->get($bundle->basePath);
+            $baseUrl = $bundle->baseUrl === null ? '' : $this->aliases->get($bundle->baseUrl);
         }
 
         if (!$this->isRelative($asset) || strncmp($asset, '/', 1) === 0) {

--- a/tests/View/WebViewTest.php
+++ b/tests/View/WebViewTest.php
@@ -63,7 +63,7 @@ final class WebViewTest extends TestCase
 
         $this->webView->registerJsFile($this->aliases->get('@web/js/somefile.js'), ['position' => WebView::POS_BEGIN]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString('<body>' . PHP_EOL . '<script src="/baseUrl/js/somefile.js"></script>', $html);
+        $this->assertStringContainsString('<body>' . "\n" . '<script src="/baseUrl/js/somefile.js"></script>', $html);
 
         $this->webView->registerJsFile($this->aliases->get('@web/js/somefile.js'), ['position' => WebView::POS_END]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Fixed: Argument 1 passed to Yiisoft\Aliases\Aliases::isAlias() must be of the type string, null given, called in src/Aliases.php on line 132.

Fixed PHP_EOL in testcase