### PR TITLE
Fix typehint

### DIFF
--- a/src/Widget/Block.php
+++ b/src/Widget/Block.php
@@ -32,9 +32,6 @@ namespace Yiisoft\Widget;
  *
  * Second parameter defines if block content should be outputted which is desired when rendering its content but isn't
  * desired when redefining it in subviews.
- *
- * @method static Block begin()
- * @method static Block end()
  */
 class Block extends Widget
 {

--- a/src/Widget/Breadcrumbs.php
+++ b/src/Widget/Breadcrumbs.php
@@ -2,8 +2,8 @@
 
 namespace Yiisoft\Widget;
 
-use Yiisoft\Html\Html;
 use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Html\Html;
 
 /**
  * Breadcrumbs displays a list of links indicating the position of the current page in the whole site hierarchy.
@@ -38,8 +38,6 @@ use Yiisoft\Arrays\ArrayHelper;
  * echo Breadcrumbs::widget()
  *     ->links() => isset($this->params['breadcrumbs']) ? $this->params['breadcrumbs'] : [];
  * ```
- *
- * @method static Breadcrumbs widget()
  */
 class Breadcrumbs extends Widget
 {

--- a/src/Widget/ContentDecorator.php
+++ b/src/Widget/ContentDecorator.php
@@ -29,9 +29,6 @@ namespace Yiisoft\Widget;
  *
  * <?php $this->endContent() ?>
  * ```
- *
- * @method static ContentDecorator begin()
- * @method static ContentDecorator end()
  */
 class ContentDecorator extends Widget
 {

--- a/src/Widget/Menu.php
+++ b/src/Widget/Menu.php
@@ -26,8 +26,6 @@ use Yiisoft\Html\Html;
  *         ['label' => 'Login', 'url' => 'site/login', 'visible' => true],
  *     ]);
  * ```
- *
- * @method static Menu widget()
  */
 class Menu extends Widget
 {

--- a/src/Widget/Widget.php
+++ b/src/Widget/Widget.php
@@ -19,24 +19,13 @@ use Yiisoft\Widget\Event\BeforeRun;
 class Widget implements ViewContextInterface
 {
     /**
-     * @var EventDispatcherInterface event handler.
-     */
-    protected static $eventDispatcher;
-    /**
-     * @var Widget $widget
-     */
-    protected static $widget;
-    /**
      * The widgets that are currently being rendered (not ended). This property is maintained by {@see static::begin()}
      * and {@see static::end()} methods.
-     *
-     * @var Widget[] $stack
      */
-    protected static $stack;
-    /**
-     * @var WebView $view
-     */
-    protected static $webView;
+    protected static array $stack;
+    protected static EventDispatcherInterface $eventDispatcher;
+    protected static Widget $widget;
+    protected static WebView $webView;
 
     public function __construct(EventDispatcherInterface $eventDispatcher, WebView $webView)
     {

--- a/src/Widget/Widget.php
+++ b/src/Widget/Widget.php
@@ -51,11 +51,11 @@ class Widget implements ViewContextInterface
      * A matching {@see end()} call should be called later. As some widgets may use output buffering, the {@see end()}
      * call should be made in the same view to avoid breaking the nesting of output buffers.
      *
-     * @return Widget the newly created widget instance.
+     * @return static the newly created widget instance.
      *
      * {@see end()}
      */
-    public static function begin(): Widget
+    public static function begin(): self
     {
         $widget = new static(self::$eventDispatcher, self::$webView);
 
@@ -69,13 +69,13 @@ class Widget implements ViewContextInterface
      *
      * Note that the rendering result of the widget is directly echoed out
      *
-     * @return Widget the widget instance that is ended
+     * @return static the widget instance that is ended
      *
      * @throws BadFunctionCallException if {@see begin()]} and {@see end()} calls are not properly nested.
      *
-     * {@see begin()}
+     * @see begin()
      */
-    public static function end(): Widget
+    public static function end(): self
     {
         if (empty(self::$stack)) {
             throw new BadFunctionCallException(
@@ -99,9 +99,9 @@ class Widget implements ViewContextInterface
     /**
      * Creates a widget instance.
      *
-     * @return Widget $widget.
+     * @return static $widget.
      */
-    public static function widget(): Widget
+    public static function widget(): self
     {
         $widget = new static(self::$eventDispatcher, self::$webView);
 

--- a/tests/Widget/Stubs/TestWidget.php
+++ b/tests/Widget/Stubs/TestWidget.php
@@ -7,7 +7,6 @@ use Yiisoft\Widget\Widget;
 
 /**
  * TestWidget
- * @method static TestWidget widget()
  */
 class TestWidget extends Widget
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌

`Widget::begin()`, `Widget::end()`, `Widget::widget()` at now has typehint for child class