### PR TITLE
Prevent error if title is not set

### DIFF
--- a/src/WebView.php
+++ b/src/WebView.php
@@ -542,9 +542,9 @@ class WebView extends View
      *
      * @return string
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
-        return $this->title;
+        return $this->title ?? null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

I was not sure an empty string or `null` would be the preferred solution, but in case `null` is preferred this can easily be adjusted.