### PR TITLE
Add FragmentCache functional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         },
         "config-plugin": {
             "common": "config/common.php",
-            "tests": "config/tests.php"
+            "tests": [
+                "$common",
+                "config/tests.php"
+            ]
         }
     },
     "autoload": {

--- a/config/common.php
+++ b/config/common.php
@@ -1,4 +1,8 @@
 <?php
 
+use Yiisoft\View\FragmentCache;
+use Yiisoft\View\FragmentCacheInterface;
+
 return [
+    FragmentCacheInterface::class => FragmentCache::class,
 ];

--- a/config/tests.php
+++ b/config/tests.php
@@ -49,18 +49,20 @@ return [
         $aliases = $container->get(Aliases::class);
         $eventDispatcher = $container->get(EventDispatcherInterface::class);
         $theme = $container->get(Theme::class);
+        $fragmentCache = $container->get(FragmentCacheInterface::class);
         $logger = $container->get(LoggerInterface::class);
 
-        return new WebView($aliases->get('@view'), $theme, $eventDispatcher, $logger);
+        return new WebView($aliases->get('@view'), $theme, $eventDispatcher, $fragmentCache, $logger);
     },
 
     View::class => function (ContainerInterface $container) {
         $aliases = $container->get(Aliases::class);
         $eventDispatcher = $container->get(EventDispatcherInterface::class);
         $theme = $container->get(Theme::class);
+        $fragmentCache = $container->get(FragmentCacheInterface::class);
         $logger = $container->get(LoggerInterface::class);
 
-        return new View($aliases->get('@view'), $theme, $eventDispatcher, $logger);
+        return new View($aliases->get('@view'), $theme, $eventDispatcher, $fragmentCache, $logger);
     },
 
     FragmentCacheInterface::class => FragmentCache::class,

--- a/config/tests.php
+++ b/config/tests.php
@@ -9,6 +9,8 @@ use Yiisoft\EventDispatcher\Dispatcher\Dispatcher;
 use Yiisoft\EventDispatcher\Provider\Provider;
 use Yiisoft\Factory\Definitions\Reference;
 use Yiisoft\Log\Logger;
+use Yiisoft\View\FragmentCache;
+use Yiisoft\View\FragmentCacheInterface;
 use Yiisoft\View\Tests\Mocks\WebViewPlaceholderMock;
 use Yiisoft\View\Theme;
 use Yiisoft\View\View;
@@ -17,10 +19,6 @@ use Yiisoft\View\WebView;
 $tempDir = sys_get_temp_dir();
 
 return [
-    ContainerInterface::class => function (ContainerInterface $container) {
-        return $container;
-    },
-
     Aliases::class => [
         '@root' => dirname(__DIR__, 1),
         '@public' => '@root/tests/public',
@@ -65,12 +63,15 @@ return [
         return new View($aliases->get('@view'), $theme, $eventDispatcher, $logger);
     },
 
+    FragmentCacheInterface::class => FragmentCache::class,
+
     WebViewPlaceholderMock::class => function (ContainerInterface $container) {
         $aliases = $container->get(Aliases::class);
         $eventDispatcher = $container->get(EventDispatcherInterface::class);
         $theme = $container->get(Theme::class);
+        $fragmentCache = $container->get(FragmentCacheInterface::class);
         $logger = $container->get(LoggerInterface::class);
 
-        return new WebViewPlaceholderMock($aliases->get('@view'), $theme, $eventDispatcher, $logger);
+        return new WebViewPlaceholderMock($aliases->get('@view'), $theme, $eventDispatcher, $fragmentCache, $logger);
     },
 ];

--- a/src/DynamicContentAwareTrait.php
+++ b/src/DynamicContentAwareTrait.php
@@ -61,7 +61,7 @@ trait DynamicContentAwareTrait
         if ($isRestoredFromCache) {
             $view = $this->getView();
             foreach ($placeholders as $name => $statements) {
-                $view->addDynamicPlaceholder($name, $statements);
+                $view->addDynamicPlaceholder((string)$name, $statements);
             }
         }
 

--- a/src/DynamicContentAwareTrait.php
+++ b/src/DynamicContentAwareTrait.php
@@ -54,7 +54,7 @@ trait DynamicContentAwareTrait
         if (count($this->getView()->getDynamicContents()) === 0) {
             // outermost cache: replace placeholder with dynamic content
             foreach ($placeholders as $name => $statements) {
-                $placeholders[$name] = $this->getView()->evaluateDynamicContent($statements);
+                $placeholders[$name] = (string)$this->getView()->evaluateDynamicContent($statements);
             }
             $content = strtr($content, $placeholders);
         }

--- a/src/FragmentCache.php
+++ b/src/FragmentCache.php
@@ -29,34 +29,16 @@ class FragmentCache implements FragmentCacheInterface, DynamicContentAwareInterf
      */
     public bool $enabled = true;
 
-    /**
-     * @var CacheInterface|null
-     */
     private ?CacheInterface $cache;
 
-    /**
-     * @var string
-     */
     private string $content = '';
 
-    /**
-     * @var Dependency|null
-     */
     private ?Dependency $dependency = null;
 
-    /**
-     * @var string
-     */
     private string $id;
 
-    /**
-     * @var string
-     */
     private string $key;
 
-    /**
-     * @var LoggerInterface
-     */
     private LoggerInterface $logger;
 
     /**
@@ -64,14 +46,8 @@ class FragmentCache implements FragmentCacheInterface, DynamicContentAwareInterf
      */
     private array $renderVars;
 
-    /**
-     * @var int
-     */
     private int $savedObLevel;
 
-    /**
-     * @var int
-     */
     private int $status = self::STATUS_NO;
 
     /**
@@ -79,9 +55,6 @@ class FragmentCache implements FragmentCacheInterface, DynamicContentAwareInterf
      */
     private array $vars;
 
-    /**
-     * @var View|null
-     */
     private ?View $view = null;
 
     public function __construct(?CacheInterface $cache, LoggerInterface $logger)

--- a/src/FragmentCache.php
+++ b/src/FragmentCache.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View;
+
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
+use RuntimeException;
+use Yiisoft\Cache\CacheInterface as YiiCacheInterface;
+use Yiisoft\Cache\Dependency\Dependency;
+
+class FragmentCache implements FragmentCacheInterface, DynamicContentAwareInterface
+{
+    use DynamicContentAwareTrait;
+
+    private const NOCACHE = -1;
+
+    /**
+     * @var int number of seconds that the data can remain valid in cache.
+     * Use 0 to indicate that the cached data will never expire.
+     */
+    public int $duration = 60;
+
+    /**
+     * @var bool whether to enable the fragment cache. You may use this property to turn on and off
+     * the fragment cache according to specific setting (e.g. enable fragment cache only for GET requests).
+     */
+    public bool $enabled = true;
+
+    /**
+     * @var CacheInterface|null
+     */
+    private ?CacheInterface $cache;
+
+    /**
+     * @var string
+     */
+    private string $content = '';
+
+    /**
+     * @var Dependency|null
+     */
+    private ?Dependency $dependency = null;
+
+    /**
+     * @var string
+     */
+    private string $id;
+
+    /**
+     * @var string|array
+     */
+    private $key;
+
+    /**
+     * @var LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * @var string[]
+     */
+    private array $renderVars;
+
+    /**
+     * @var int
+     */
+    private int $savedObLevel;
+
+    /**
+     * @var int
+     */
+    private int $status = self::STATUS_NO;
+
+    /**
+     * @var string[]
+     */
+    private array $vars;
+
+    /**
+     * @var View|null
+     */
+    private ?View $view = null;
+
+    public function __construct(?CacheInterface $cache, LoggerInterface $logger)
+    {
+        $this->cache = $cache;
+        $this->logger = $logger;
+    }
+
+    public function __clone()
+    {
+        $this->clearData();
+        $this->savedObLevel = self::NOCACHE;
+        $this->status = self::STATUS_INIT;
+    }
+
+    public function beginCache(?View $view, string $id, array $params = [], array $vars = []): self
+    {
+        $obj = clone $this;
+        $obj->view = $view;
+        $obj->id = $id;
+        if (isset($params['duration'])) {
+            $obj->duration = (int)$params['duration'];
+        }
+        if (isset($params['enabled'])) {
+            $obj->enabled = $obj->enabled && (bool)$params['enabled'];
+        }
+        if (isset($params['cache'])) {
+            $obj->cache = $params['cache'];
+        }
+        $obj->vars = $vars;
+        if (!$obj->cache || !$obj->enabled) {
+            $obj->status = self::STATUS_BEGIN;
+            return $obj;
+        }
+        if (isset($params['dependency'])) {
+            if (!($obj->cache instanceof YiiCacheInterface)) {
+                throw new RuntimeException('Dependencies are available only for the cache supporting the interface Yiisoft\Cache\CacheInterface.');
+            }
+            $obj->dependency = $params['dependency'];
+        }
+        $obj->key = $obj->buildKey(isset($params['variations']) ? [$id, $params['variations']] : $id);
+        if ($obj->readFromCache()) {
+            $obj->status = self::STATUS_IN_CACHE;
+            return $obj;
+        }
+        $obj->status = self::STATUS_BEGIN;
+        $obj->startCache();
+        return $obj;
+    }
+
+    /**
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function endCache(): void
+    {
+        if ($this->status === self::STATUS_IN_CACHE) {
+            $this->status = self::STATUS_END;
+            $this->logger->debug("Rendering Fragment (from cache): {$this->id}");
+            echo $this->content;
+            $this->clearData();
+            return;
+        }
+        if ($this->status !== self::STATUS_BEGIN) {
+            throw new RuntimeException('This method is not available in the current state.');
+        }
+        $this->status = self::STATUS_END;
+        if ($this->savedObLevel === self::NOCACHE) {
+            $this->logger->debug("Rendering Fragment (cache disabled): {$this->id}");
+            return;
+        }
+        $this->logger->debug("Rendering Fragment (miss): {$this->id}");
+        $content = $this->getCachedContent();
+        if ($this->view) {
+            $this->view->popDynamicContent($this);
+        }
+        if ($this->enabled) {
+            if ($this->cache instanceof YiiCacheInterface) {
+                $this->cache->set($this->key, [$content, $this->renderVars, $this->getDynamicPlaceholders()], $this->duration, $this->dependency);
+            } else {
+                $this->cache->set($this->key, [$content, $this->renderVars, $this->getDynamicPlaceholders()], $this->duration);
+            }
+        }
+        $content = $this->updateContent($content, $this->getDynamicPlaceholders());
+        echo $content;
+        $this->clearData();
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function renderVar(string $name): string
+    {
+        if ($this->savedObLevel === self::NOCACHE) {
+            return \strval($obj->vars[$name] ?? '');
+        }
+        if (!\array_key_exists($name, $this->renderVars)) {
+            $this->renderVars[$name] = true;
+        }
+        return "<![CDATA[YII-VAR-$name]]>";
+    }
+
+    protected function getView(): View
+    {
+        if (!$this->view) {
+            throw new RuntimeException('The view is undefined.');
+        }
+        return $this->view;
+    }
+
+    /**
+     * Builds a normalized cache key from a given key.
+     *
+     * If the given key is a string containing alphanumeric characters only and no more than 32 characters,
+     * then the key will be returned back as it is, integers will be converted to strings. Otherwise, a normalized key
+     * is generated by serializing the given key and applying MD5 hashing.
+     * @param mixed $key the key to be normalized
+     * @return string the generated cache key
+     */
+    private function buildKey($key): string
+    {
+        $jsonKey = \json_encode($key);
+        if ($jsonKey === false) {
+            throw new InvalidArgumentException('Invalid key. ' . \json_last_error_msg());
+        }
+        return \md5($jsonKey);
+    }
+
+    /**
+     * Clearing memory after caching is complete.
+     */
+    private function clearData()
+    {
+        $this->content = '';
+        $this->dependency = null;
+        $this->id = '';
+        $this->key = '';
+        $this->renderVars = [];
+        $this->vars = [];
+        $this->view = null;
+        $this->setDynamicPlaceholders([]);
+    }
+
+    private function getCachedContent(): string
+    {
+        if (\ob_get_level() < $this->savedObLevel) {
+            throw new RuntimeException('The cache level is less than expected.');
+        }
+        while (\ob_get_level() > $this->savedObLevel) {
+            if (!\ob_end_flush()) {
+                if (!\is_string($content = \ob_get_clean())) {
+                    throw new RuntimeException('It is not possible to delete a higher-level cache.');
+                }
+                echo $content;
+            }
+        }
+        return \ob_get_clean() ?: '';
+    }
+
+    private function readFromCache(): bool
+    {
+        if (!\is_array($value = $this->cache->get($this->key)) || \count($value) !== 3) {
+            return false;
+        }
+        [$content, $renderVars, $placeholders] = $value;
+        if (!\is_string($content) || !\is_array($renderVars) || !\is_array($placeholders)) {
+            return false;
+        }
+        if ($placeholders && !$this->view) {
+            return false;
+        }
+        $this->renderVars = $renderVars;
+        $this->content = $this->updateContent($content, $placeholders, true);
+        return true;
+    }
+
+    private function startCache(): void
+    {
+        if (!\ob_start()) {
+            return;
+        }
+        \ob_implicit_flush(0);
+        $this->savedObLevel = \ob_get_level();
+        if ($this->view) {
+            $this->view->pushDynamicContent($this);
+        }
+    }
+
+    private function updateContent(string $content, array $placeholders, bool $isRestoredFromCache = false): string
+    {
+        $content = $this->updateVarContent($content);
+        if ($this->view) {
+            $content = $this->updateDynamicContent($content, $placeholders, $isRestoredFromCache);
+        }
+        return $content;
+    }
+
+    private function updateVarContent(string $content): string
+    {
+        if (!$this->renderVars) {
+            return $content;
+        }
+        $vars = [];
+        foreach (\array_merge($this->renderVars, \array_keys($this->vars)) as $name => $_) {
+            $vars["<![CDATA[YII-VAR-$name]]>"] = \strval($this->vars[$name] ?? '');
+        }
+        return \strtr($content, $vars);
+    }
+}

--- a/src/FragmentCacheInterface.php
+++ b/src/FragmentCacheInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View;
+
+interface FragmentCacheInterface
+{
+    public const STATUS_BEGIN = 2;
+    public const STATUS_END = 3;
+    public const STATUS_IN_CACHE = 4;
+    public const STATUS_INIT = 1;
+    public const STATUS_NO = 0;
+
+    public function beginCache(?View $view, string $id, array $params = [], array $vars = []): self;
+
+    public function endCache(): void;
+
+    public function getStatus(): int;
+
+    public function renderVar(string $name): string;
+}

--- a/src/FragmentCacheInterface.php
+++ b/src/FragmentCacheInterface.php
@@ -12,6 +12,13 @@ interface FragmentCacheInterface
     public const STATUS_INIT = 1;
     public const STATUS_NO = 0;
 
+    /**
+     * @param View|null $view
+     * @param string $id
+     * @param array $params
+     * @param string[] $vars
+     * @return $this
+     */
     public function beginCache(?View $view, string $id, array $params = [], array $vars = []): self;
 
     public function endCache(): void;

--- a/src/View.php
+++ b/src/View.php
@@ -51,9 +51,6 @@ class View implements DynamicContentAwareInterface
      */
     private array $defaultParameters = [];
 
-    /**
-     * @var EventDispatcherInterface $eventDispatcher
-     */
     protected EventDispatcherInterface $eventDispatcher;
 
     /**
@@ -77,9 +74,6 @@ class View implements DynamicContentAwareInterface
      */
     protected Theme $theme;
 
-    /**
-     * @var FragmentCacheInterface
-     */
     private FragmentCacheInterface $fragmentCache;
 
     /**
@@ -88,23 +82,14 @@ class View implements DynamicContentAwareInterface
     private array $cacheStack = [];
 
     /**
-     * @var array a list of placeholders for embedding dynamic contents.
+     * @var string[] a list of placeholders for embedding dynamic contents.
      */
     private array $dynamicPlaceholders = [];
 
-    /**
-     * @var string
-     */
     private string $language = 'en';
 
-    /**
-     * @var LoggerInterface
-     */
     private LoggerInterface $logger;
 
-    /**
-     * @var string
-     */
     private string $sourceLanguage = 'en';
 
     /**
@@ -534,11 +519,17 @@ class View implements DynamicContentAwareInterface
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
     public function getDynamicPlaceholders(): array
     {
         return $this->dynamicPlaceholders;
     }
 
+    /**
+     * @param string[] $placeholders
+     */
     public function setDynamicPlaceholders(array $placeholders): void
     {
         $this->dynamicPlaceholders = $placeholders;
@@ -627,6 +618,12 @@ class View implements DynamicContentAwareInterface
         \ob_end_flush();
     }
 
+    /**
+     * @param string $id
+     * @param array $params
+     * @param string[] $vars
+     * @return FragmentCache|null
+     */
     public function beginCache(string $id, array $params = [], array $vars = []): ?FragmentCache
     {
         $fc = $this->fragmentCache->beginCache($this, $id, $params, $vars);

--- a/src/View.php
+++ b/src/View.php
@@ -117,6 +117,11 @@ class View implements DynamicContentAwareInterface
         $this->generatePlaceholderSignatures();
     }
 
+    public function __clone()
+    {
+        $this->generatePlaceholderSignatures();
+    }
+
     public function generatePlaceholderSignatures(): void
     {
         $this->placeholderDynamicSignature = \strtr(\base64_encode(\substr(\pack('Q', \rand(0, PHP_INT_MAX)), 0, 6)), '+/=', '012');

--- a/src/View.php
+++ b/src/View.php
@@ -544,13 +544,13 @@ class View implements DynamicContentAwareInterface
         $this->dynamicPlaceholders = $placeholders;
     }
 
-    public function addDynamicPlaceholder(string $placeholder, string $statements): void
+    public function addDynamicPlaceholder(string $name, string $statements): void
     {
         foreach ($this->cacheStack as $cache) {
-            $cache->addDynamicPlaceholder($placeholder, $statements);
+            $cache->addDynamicPlaceholder($name, $statements);
         }
 
-        $this->dynamicPlaceholders[$placeholder] = $statements;
+        $this->dynamicPlaceholders[$name] = $statements;
     }
 
     /**

--- a/src/View.php
+++ b/src/View.php
@@ -78,7 +78,7 @@ class View implements DynamicContentAwareInterface
     protected Theme $theme;
 
     /**
-     * @var FragmentCache
+     * @var FragmentCacheInterface
      */
     private FragmentCacheInterface $fragmentCache;
 

--- a/tests/FragmentCacheTest.php
+++ b/tests/FragmentCacheTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View\Tests;
+
+use Yiisoft\Files\FileHelper;
+
+/**
+ * FragmentCacheTest.
+ */
+final class FragmentCacheTest extends \Yiisoft\View\Tests\TestCase
+{
+    /**
+     * @var string path for the test files.
+     */
+    private string $testViewPath = '';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testViewPath = \sys_get_temp_dir() . '/' . \str_replace('\\', '_', \get_class($this)) . \uniqid('', false);
+
+        FileHelper::createDirectory($this->testViewPath);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        FileHelper::removeDirectory($this->testViewPath);
+    }
+}

--- a/tests/Mocks/WebViewPlaceholderMock.php
+++ b/tests/Mocks/WebViewPlaceholderMock.php
@@ -10,7 +10,7 @@ class WebViewPlaceholderMock extends WebView
 {
     public function endPage($ajaxMode = false): void
     {
-        $this->setPlaceholderSalt((string)time());
+        $this->setPlaceholderSignature((string)time());
         parent::endPage($ajaxMode);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -89,6 +89,14 @@ abstract class TestCase extends BaseTestCase
         $this->assertEquals($expected, $actual, $message);
     }
 
+    protected function assertStringContainsStringWithoutLE(string $needle, string $haystack, string $message = ''): void
+    {
+        $needle = str_replace("\r\n", "\n", $needle);
+        $haystack = str_replace("\r\n", "\n", $haystack);
+
+        $this->assertStringContainsString($needle, $haystack, $message);
+    }
+
     /**
      * Asserting same ignoring slash.
      *

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,46 +13,28 @@ use Psr\Log\LoggerInterface;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\Di\Container;
 use Yiisoft\Files\FileHelper;
+use Yiisoft\View\FragmentCacheInterface;
 use Yiisoft\View\Theme;
 use Yiisoft\View\View;
 use Yiisoft\View\WebView;
 
 abstract class TestCase extends BaseTestCase
 {
-    /**
-     * @var Aliases $aliases
-     */
-    protected $aliases;
+    protected Aliases $aliases;
 
-    /**
-     * @var ContainerInterface $container
-     */
-    private $container;
+    protected EventDispatcherInterface $eventDispatcher;
 
-    /**
-     * @var EventDispatcherInterface $eventDispatcher
-     */
-    protected $eventDispatcher;
+    protected FragmentCacheInterface $fragmentCache;
 
-    /**
-     * @var LoggerInterface $logger
-     */
-    protected $logger;
+    protected LoggerInterface $logger;
 
-    /**
-     * @var Theme $theme
-     */
-    protected $theme;
+    protected Theme $theme;
 
-    /**
-     * @var WebView $webView
-     */
-    protected $webView;
+    protected WebView $webView;
 
-    /**
-     * @var ListenerProviderInterface
-     */
-    protected $listenerProvider;
+    protected ListenerProviderInterface $listenerProvider;
+
+    private ContainerInterface $container;
 
     /**
      * setUp
@@ -71,6 +53,7 @@ abstract class TestCase extends BaseTestCase
         $this->eventDispatcher = $this->container->get(EventDispatcherInterface::class);
         $this->listenerProvider = $this->container->get(ListenerProviderInterface::class);
         $this->logger = $this->container->get(LoggerInterface::class);
+        $this->fragmentCache = $this->container->get(FragmentCacheInterface::class);
         $this->webView = $this->container->get(WebView::class);
     }
 
@@ -86,7 +69,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        $this->container = null;
+        unset($this->container);
         parent::tearDown();
     }
 
@@ -116,8 +99,8 @@ abstract class TestCase extends BaseTestCase
      */
     protected function assertSameIgnoringSlash(string $expected, string $actual): void
     {
-        $expected = str_replace(['/', '\\'], '/', $expected);
-        $actual = str_replace(['/', '\\'], '/', $actual);
+        $expected = \str_replace(['/', '\\'], '/', $expected);
+        $actual = \str_replace(['/', '\\'], '/', $actual);
         $this->assertSame($expected, $actual);
     }
 
@@ -131,13 +114,13 @@ abstract class TestCase extends BaseTestCase
      */
     protected function createView($basePath, Theme $theme = null): View
     {
-        return new View($basePath, $theme ?: new Theme(), $this->eventDispatcher, $this->logger);
+        return new View($basePath, $theme ?: new Theme(), $this->eventDispatcher, $this->fragmentCache, $this->logger);
     }
 
     protected function touch(string $path): void
     {
         FileHelper::createDirectory(dirname($path));
 
-        touch($path);
+        \touch($path);
     }
 }

--- a/tests/WebViewTest.php
+++ b/tests/WebViewTest.php
@@ -53,15 +53,15 @@ final class WebViewTest extends \Yiisoft\View\Tests\TestCase
     {
         $this->webView->registerJsFile($this->aliases->get('@baseUrl/js/somefile.js'), ['position' => WebView::POSITION_HEAD]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString("<script src=\"/baseUrl/js/somefile.js\"></script>\n</head>", $html);
+        $this->assertStringContainsStringWithoutLE("<script src=\"/baseUrl/js/somefile.js\"></script>\n</head>", $html);
 
         $this->webView->registerJsFile($this->aliases->get('@baseUrl/js/somefile.js'), ['position' => WebView::POSITION_BEGIN]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString("<body>\n<script src=\"/baseUrl/js/somefile.js\"></script>\n", $html);
+        $this->assertStringContainsStringWithoutLE("<body>\n<script src=\"/baseUrl/js/somefile.js\"></script>\n", $html);
 
         $this->webView->registerJsFile($this->aliases->get('@baseUrl/js/somefile.js'), ['position' => WebView::POSITION_END]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString("<script src=\"/baseUrl/js/somefile.js\"></script>\n</body>", $html);
+        $this->assertStringContainsStringWithoutLE("<script src=\"/baseUrl/js/somefile.js\"></script>\n</body>", $html);
     }
 
     public function testRegisterCssFileWithAlias(): void

--- a/tests/WebViewTest.php
+++ b/tests/WebViewTest.php
@@ -39,42 +39,46 @@ final class WebViewTest extends \Yiisoft\View\Tests\TestCase
     {
         $this->webView->registerJsVar('username', 'samdark');
         $html = $this->webView->render('//layout.php', ['content' => 'content']);
-        $this-> assertStringContainsString('<script>var username = "samdark";</script></head>', $html);
+        $this-> assertStringContainsString("<script>var username = \"samdark\";</script>\n</head>", $html);
 
         $this->webView->registerJsVar('objectTest', [
             'number' => 42,
             'question' => 'Unknown',
         ]);
         $html = $this->webView->render('//layout.php', ['content' => 'content']);
-        $this->assertStringContainsString('<script>var objectTest = {"number":42,"question":"Unknown"};</script></head>', $html);
+        $this->assertStringContainsString("<script>var objectTest = {\"number\":42,\"question\":\"Unknown\"};</script>\n</head>", $html);
     }
 
     public function testRegisterJsFileWithAlias(): void
     {
         $this->webView->registerJsFile($this->aliases->get('@web/js/somefile.js'), ['position' => WebView::POSITION_HEAD]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString('<script src="/baseUrl/js/somefile.js"></script></head>', $html);
+        $this->assertStringContainsString("<script src=\"/baseUrl/js/somefile.js\"></script>\n</head>", $html);
 
         $this->webView->registerJsFile($this->aliases->get('@web/js/somefile.js'), ['position' => WebView::POSITION_BEGIN]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString('<body>' . PHP_EOL . '<script src="/baseUrl/js/somefile.js"></script>', $html);
+        $this->assertStringContainsString("<body>\n<script src=\"/baseUrl/js/somefile.js\"></script>\n", $html);
 
         $this->webView->registerJsFile($this->aliases->get('@web/js/somefile.js'), ['position' => WebView::POSITION_END]);
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString('<script src="/baseUrl/js/somefile.js"></script></body>', $html);
+        $this->assertStringContainsString("<script src=\"/baseUrl/js/somefile.js\"></script>\n</body>", $html);
     }
 
     public function testRegisterCssFileWithAlias(): void
     {
         $this->webView->registerCssFile($this->aliases->get('@web/css/somefile.css'));
         $html = $this->webView->renderFile($this->layoutPath, ['content' => 'content']);
-        $this->assertStringContainsString('<link href="/baseUrl/css/somefile.css" rel="stylesheet"></head>', $html);
+        $this->assertStringContainsString("<link href=\"/baseUrl/css/somefile.css\" rel=\"stylesheet\">\n</head>", $html);
     }
 
     public function testPlaceholders(): void
     {
+        $webView = $this->getContainer()->get(WebView::class);
+        $signature = $webView->getPlaceholderSignature();
+        $html = $webView->renderFile($this->layoutPath, ['content' => 'content']);
+        $this->assertStringNotContainsString($signature, $html);
+
         $webView = $this->getContainer()->get(WebViewPlaceholderMock::class);
-        $webView->setPlaceholderSalt('apple');
         $signature = $webView->getPlaceholderSignature();
         $html = $webView->renderFile($this->layoutPath, ['content' => 'content']);
         $this->assertStringContainsString($signature, $html);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | https://github.com/yiisoft/view/issues/10

## Changes

#### DynamicContentAwareTrait.php
  - Fixed type mismatch error if evaluateDynamicContent method returns non-string result.

#### View.php
  - Minor fixes in PHPDOC.
  - Added private property FragmentCacheInterface $fragmentCache.
  - Added private property string $placeholderDynamicSignature. It contains a random signature to fix the signature intersection issue.
  - Added $fragmentCache initialization to the constructor.
  - The setPlaceholderSalt method is replaced by generatePlaceholderSignatures. This method populates the $placeholderSignature and $placeholderDynamicSignature properties.
  - Backslash added to basic php functions.
  - The renderDynamic method now uses a dynamic (random) signature, because when using a constant signature, an error occurred with the intersection of dynamic insert names when using data from the cache in another cached fragment.
  - Added $ instance parameter to the popDynamicContent method to check the correct cache closing sequence.
  - Added a public beginCache(string $id, array $params = [], array $vars = []): ?FragmentCache. This method starts fragment caching and returns an object of the FragmentCache class or null if the data is found in the cache. The parameters of the method are the same as those of the beginCache method of the FragmentCache class. If data is found in the cache, it will be automatically output to the stream. If the data is not found in the cache, it is necessary to generate new data and at the end call the endCache method on the returned object to save the data in the cache and finish caching.
  
#### WebView.php
  - Calls of methods registerMetaTag, registerLinkTag, registerCss, registerCssFile, registerJs, registerJsFile, registerJsVar, setCssFiles, setJsFiles, setTitle are now cached along with the main content.
  
#### Added class Yiisoft\View\FragmentCache.

#### Added Yiisoft\View\FragmentCacheInterface interface.
  - This interface is used in the Yiisoft\View\View class to implement caching.
  
#### Description of the implementation of the Yiisoft\View\FragmentCache class.
  - This class implements the Yiisoft\View\FragmentCacheInterface interface and is used in the Yiisoft\View\View class.
  - Public properties:
    - int $duration = 60 - Caching time (can be changed during content generation).
    - bool $enabled = true - Cache activity (can be changed during content generation to false, changing from false to true will have no effect).
  - Public methods
    - beginCache(?View $view, string $id, array $params = [], array $vars = []): self
      - The method returns a cloned instance of itself, tries to read the content from the cache, and if it fails, starts caching.
      - Method parameters
        - $view - a link to a Yiisoft\View\View instance to register itself as an object of the Yiisoft\View\DynamicContentAwareInterface.
        - $id - String unique identifier of the cached block.
        - $params - Array of parameters. Possible parameters:
          - duration (int) - Caching time.
          - enabled (bool) - Cache activity (ignored if caching was disabled earlier).
          - cache (Psr\SimpleCache\CacheInterface|Yiisoft\Cache\CacheInterface)
          - dependency - If you use a cache that supports the Yiisoft\Cache\CacheInterface interface, you can transfer dependencies here.
          - variations - Additional data defining the uniqueness (variability) of the data. Added to id for variability.
        - $vars - Array of variables used in the fragment. Variables are not saved in the cache.
      - endCache()
        - The method ends the previously started caching with the beginCache method.
      - getStatus(): int
        - The method returns the status of the cached object. Possible statuses:
          - STATUS_NO - This is the root object used to call the beginCache method.
          - STATUS_INIT - This is the cloned object during the initialization phase.
          - STATUS_BEGIN - Caching in progress (after calling beginCache).
          - STATUS_END - Caching completed (after calling endCache).
          - STATUS_IN_CACHE - The content was received from the cache, a call to endCache is required to output data to the stream (after calling beginCache).
      - renderVar(string $name): string
        - The method returns the value of the variable (the signature or the value itself).

#### Variable content
  - Sometimes it is necessary to cache a large fragment, but there is a line in it that may change. You can use the variations value of the beginCache method parameters, but unlike variations, using variables allows you to store one instance of cached data.
  - Variable content differs from dynamic content in that it is calculated not after the formation of all content, but before the start of caching and can interact with the current environment and data. Also, when re-caching, the top-level cache will cache the variable content as text, not as variable content.

## Configuration example:
```php
final class WebViewProvider extends ServiceProvider
{
    public function register(Container $container): void
    {
        $container->set(FragmentCacheInterface::class, FragmentCache::class);
        $container->set(WebView::class, function (ContainerInterface $container, Aliases $aliases, Theme $theme, EventDispatcherInterface $eventDispatcher, FragmentCacheInterface $fragmentCache, LoggerInterface $logger) {
            $webView = new WebView($aliases->get($this->basePath), $theme, $eventDispatcher, $fragmentCache, $logger);

            $defaultParameters = [];
            foreach ($this->defaultParameters as $key => $value) {
                $defaultParameters[$key] = $container->get($value);
            }
            $webView->setDefaultParameters($defaultParameters);

            return $webView;
        });
    }
}
```

## An example of using dynamic content:
```php
if ($cache = $this->beginCache('test/test')):

?> Data Data Data <?= $this->renderDynamic('return date("d.m.Y H:i");') ?> Data Data Data <?php

	$cache->endCache();
endif;
```

## An example of using variables (they are not saved in the cache):
```php
if ($cache = $this->beginCache('test/test', ['duration' => 3600], ['content' => $content])):

?> Data Data Data <?= $cache->renderVar('content') ?> Data Data Data <?php

	$cache->endCache();
endif;
```

## Tests and documentation
There are no tests and documentation.
