### PR TITLE
Fix config + Update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
         "yiisoft/json": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "roave/infection-static-analysis-plugin": "^1.5",
+        "phpunit/phpunit": "^9.5",
+        "roave/infection-static-analysis-plugin": "^1.6",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.2",
+        "vimeo/psalm": "^4.3",
         "yiisoft/aliases": "^1.1",
         "yiisoft/cache": "^3.0@dev",
         "yiisoft/di": "^3.0@dev",

--- a/config/params.php
+++ b/config/params.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'yiisoft/view' => [
-        'basePath' => '@views',
+        'basePath' => '',
         'defaultParameters' => [],
         'theme' => [
             'pathMap' => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

PR replace value of `$params['yiisoft/view']['basePath']` from `@views` to empty string.

For example, I can use in console app `yiisoft/yii-db-migration` which used `yiisoft/view`. `@views` in my app not setted and throws error.

In [app template](https://github.com/yiisoft/app/blob/master/config/params.php#L57) and [demo app](https://github.com/yiisoft/yii-demo/blob/master/config/params.php#L51)  `$params['yiisoft/view']['basePath']` already is `@views`.