### PR TITLE
Minor fixes

### DIFF
--- a/src/View.php
+++ b/src/View.php
@@ -455,7 +455,7 @@ class View implements DynamicContentAwareInterface
      * @param string $output the rendering result of the view file. Updates to this parameter
      * will be passed back and returned by {@see renderFile()}.
      */
-    public function afterRender(string $viewFile, array $parameters, &$output): string
+    public function afterRender(string $viewFile, array $parameters, $output): string
     {
         $event = new AfterRender($viewFile, $parameters, $output);
         $event = $this->eventDispatcher->dispatch($event);

--- a/src/View.php
+++ b/src/View.php
@@ -455,7 +455,7 @@ class View implements DynamicContentAwareInterface
      * @param string $output the rendering result of the view file. Updates to this parameter
      * will be passed back and returned by {@see renderFile()}.
      */
-    public function afterRender(string $viewFile, array $parameters, $output): string
+    public function afterRender(string $viewFile, array $parameters, string $output): string
     {
         $event = new AfterRender($viewFile, $parameters, $output);
         $event = $this->eventDispatcher->dispatch($event);

--- a/src/View.php
+++ b/src/View.php
@@ -452,8 +452,8 @@ class View implements DynamicContentAwareInterface
      *
      * @param string $viewFile the view file being rendered.
      * @param array $parameters the parameter array passed to the {@see render()} method.
-     * @param string $output the rendering result of the view file. Updates to this parameter
-     * will be passed back and returned by {@see renderFile()}.
+     * @param string $output the rendering result of the view file.
+    * @return string Updated output. It will be passed to {@see renderFile()} and returned.
      */
     public function afterRender(string $viewFile, array $parameters, string $output): string
     {

--- a/src/WebView.php
+++ b/src/WebView.php
@@ -581,7 +581,7 @@ class WebView extends View
      *
      * @param string $value
      */
-    public function setTitle($value): void
+    public function setTitle(string $value): void
     {
         $this->title = $value;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌ (might be)
| New feature?  | ❌
| Breaks BC?    | ✔️/❌ (potential)
| Fixed issues  | n/a

- add couple missing param `string` type declarations
- remove reference from param as it is not used in body (should it propagate to `AfterRender` by design?)

p.s. `afterRender` function phpDoc is missing `@return` declaration