### PR TITLE
Add methods WebView::registerMeta() and WebView::registerLink() + support position for link tags

### DIFF
--- a/src/BaseView.php
+++ b/src/BaseView.php
@@ -113,6 +113,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $new;
     }
 
+    /**
+     * @return static
+     */
     public function withRenderers(array $renderers): self
     {
         $new = clone $this;
@@ -120,6 +123,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $new;
     }
 
+    /**
+     * @return static
+     */
     public function withLanguage(string $language): self
     {
         $new = clone $this;
@@ -127,6 +133,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $new;
     }
 
+    /**
+     * @return static
+     */
     public function withSourceLanguage(string $language): self
     {
         $new = clone $this;
@@ -134,6 +143,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $new;
     }
 
+    /**
+     * @return static
+     */
     public function withContext(ViewContextInterface $context): self
     {
         $new = clone $this;
@@ -161,6 +173,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $this->defaultExtension;
     }
 
+    /**
+     * @return static
+     */
     public function withDefaultExtension(string $defaultExtension): self
     {
         $new = clone $this;
@@ -173,6 +188,9 @@ abstract class BaseView implements DynamicContentAwareInterface
         return $this->defaultParameters;
     }
 
+    /**
+     * @return static
+     */
     public function withDefaultParameters(array $defaultParameters): self
     {
         $new = clone $this;

--- a/src/WebView.php
+++ b/src/WebView.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Psr\EventDispatcher\StoppableEventInterface;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Link;
+use Yiisoft\Html\Tag\Meta;
 use Yiisoft\Html\Tag\Script;
 use Yiisoft\Html\Tag\Style;
 use Yiisoft\Json\Json;
@@ -109,9 +110,10 @@ final class WebView extends BaseView
     private string $title = '';
 
     /**
-     * @var array the registered meta tags.
+     * @var Meta[] The registered meta tags.
      *
-     * {@see registerMetaTag()}
+     * @see registerMeta()
+     * @see registerMetaTag()
      */
     private array $metaTags = [];
 
@@ -291,7 +293,7 @@ final class WebView extends BaseView
      * For example, a description meta tag can be added like the following:
      *
      * ```php
-     * $view->registerMetaTag([
+     * $view->registerMeta([
      *     'name' => 'description',
      *     'content' => 'This website is about funny raccoons.'
      * ]);
@@ -299,18 +301,24 @@ final class WebView extends BaseView
      *
      * will result in the meta tag `<meta name="description" content="This website is about funny raccoons.">`.
      *
-     * @param array $options the HTML attributes for the meta tag.
+     * @param array $attributes the HTML attributes for the meta tag.
      * @param string $key the key that identifies the meta tag. If two meta tags are registered with the same key, the
      * latter will overwrite the former. If this is null, the new meta tag will be appended to the
      * existing ones.
      */
-    public function registerMetaTag(array $options, string $key = null): void
+    public function registerMeta(array $attributes, ?string $key = null): void
     {
-        if ($key === null) {
-            $this->metaTags[] = Html::meta()->attributes($options)->render();
-        } else {
-            $this->metaTags[$key] = Html::meta()->attributes($options)->render();
-        }
+        $this->registerMetaTag(Html::meta($attributes), $key);
+    }
+
+    /**
+     * Registers a {@see Meta} tag.
+     */
+    public function registerMetaTag(Meta $meta, ?string $key = null): void
+    {
+        $key === null
+            ? $this->metaTags[] = $meta
+            : $this->metaTags[$key] = $meta;
     }
 
     /**

--- a/src/WebView.php
+++ b/src/WebView.php
@@ -7,6 +7,7 @@ namespace Yiisoft\View;
 use InvalidArgumentException;
 use Psr\EventDispatcher\StoppableEventInterface;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Link;
 use Yiisoft\Html\Tag\Script;
 use Yiisoft\Html\Tag\Style;
 use Yiisoft\Json\Json;
@@ -84,6 +85,7 @@ final class WebView extends BaseView
     private const DEFAULT_POSITION_JS_FILE = self::POSITION_END;
     private const DEFAULT_POSITION_JS_VARIABLE = self::POSITION_HEAD;
     private const DEFAULT_POSITION_JS_STRING = self::POSITION_END;
+    private const DEFAULT_POSITION_LINK = self::POSITION_HEAD;
 
     /**
      * This is internally used as the placeholder for receiving the content registered for the head section.
@@ -114,9 +116,12 @@ final class WebView extends BaseView
     private array $metaTags = [];
 
     /**
-     * @var array the registered link tags.
+     * @var array The registered link tags.
      *
-     * {@see registerLinkTag()}
+     * @psalm-var array<int, Link[]>
+     *
+     * @see registerLink()
+     * @see registerLinkTag()
      */
     private array $linkTags = [];
 
@@ -315,7 +320,7 @@ final class WebView extends BaseView
      * following:
      *
      * ```php
-     * $view->registerLinkTag(['rel' => 'icon', 'type' => 'image/png', 'href' => '/myicon.png']);
+     * $view->registerLink(['rel' => 'icon', 'type' => 'image/png', 'href' => '/myicon.png']);
      * ```
      *
      * which will result in the following HTML: `<link rel="icon" type="image/png" href="/myicon.png">`.
@@ -323,18 +328,28 @@ final class WebView extends BaseView
      * **Note:** To register link tags for CSS stylesheets, use {@see registerCssFile()]} instead, which has more
      * options for this kind of link tag.
      *
-     * @param array $options the HTML attributes for the link tag.
+     * @param array $attributes The HTML attributes for the link tag.
+     * @param int $position The position at which the link tag should be inserted in a page.
      * @param string|null $key the key that identifies the link tag. If two link tags are registered with the same
      * key, the latter will overwrite the former. If this is null, the new link tag will be appended
      * to the existing ones.
      */
-    public function registerLinkTag(array $options, ?string $key = null): void
+    public function registerLink(
+        array $attributes,
+        int $position = self::DEFAULT_POSITION_LINK,
+        ?string $key = null
+    ): void {
+        $this->registerLinkTag(Html::link()->attributes($attributes), $position, $key);
+    }
+
+    /**
+     * Registers a {@see Link} tag.
+     */
+    public function registerLinkTag(Link $link, int $position = self::DEFAULT_POSITION_LINK, ?string $key = null): void
     {
-        if ($key === null) {
-            $this->linkTags[] = Html::link()->attributes($options)->render();
-        } else {
-            $this->linkTags[$key] = Html::link()->attributes($options)->render();
-        }
+        $key === null
+            ? $this->linkTags[$position][] = $link
+            : $this->linkTags[$position][$key] = $link;
     }
 
     /**
@@ -485,8 +500,8 @@ final class WebView extends BaseView
             $lines[] = implode("\n", $this->metaTags);
         }
 
-        if (!empty($this->linkTags)) {
-            $lines[] = implode("\n", $this->linkTags);
+        if (!empty($this->linkTags[self::POSITION_HEAD])) {
+            $lines[] = implode("\n", $this->linkTags[self::POSITION_HEAD]);
         }
         if (!empty($this->cssFiles[self::POSITION_HEAD])) {
             $lines[] = implode("\n", $this->cssFiles[self::POSITION_HEAD]);
@@ -514,6 +529,9 @@ final class WebView extends BaseView
     protected function renderBodyBeginHtml(): string
     {
         $lines = [];
+        if (!empty($this->linkTags[self::POSITION_BEGIN])) {
+            $lines[] = implode("\n", $this->linkTags[self::POSITION_BEGIN]);
+        }
         if (!empty($this->cssFiles[self::POSITION_BEGIN])) {
             $lines[] = implode("\n", $this->cssFiles[self::POSITION_BEGIN]);
         }
@@ -545,6 +563,9 @@ final class WebView extends BaseView
     {
         $lines = [];
 
+        if (!empty($this->linkTags[self::POSITION_END])) {
+            $lines[] = implode("\n", $this->linkTags[self::POSITION_END]);
+        }
         if (!empty($this->cssFiles[self::POSITION_END])) {
             $lines[] = implode("\n", $this->cssFiles[self::POSITION_END]);
         }

--- a/tests/WebViewTest.php
+++ b/tests/WebViewTest.php
@@ -189,14 +189,47 @@ final class WebViewTest extends TestCase
         $this->assertStringContainsString('[HEAD]<meta name="keywords" content="yii">[/HEAD]', $html);
     }
 
-    public function testRegisterLinkTag(): void
+    public function dataRegisterLink(): array
+    {
+        return [
+            ['[HEAD]<link href="/main.css">[/HEAD]', WebView::POSITION_HEAD],
+            ['[BEGINBODY]<link href="/main.css">[/BEGINBODY]', WebView::POSITION_BEGIN],
+            ['[ENDBODY]<link href="/main.css">[/ENDBODY]', WebView::POSITION_END],
+        ];
+    }
+
+    /**
+     * @dataProvider dataRegisterLink
+     */
+    public function testRegisterLink(string $expected, ?int $position): void
     {
         $webView = TestHelper::createWebView();
 
-        $webView->registerLinkTag(['href' => '/main.css']);
+        $position === null
+            ? $webView->registerLink(['href' => '/main.css'])
+            : $webView->registerLink(['href' => '/main.css'], $position);
 
         $html = $webView->render('//positions.php');
-        $this->assertStringContainsString('[HEAD]<link href="/main.css">[/HEAD]', $html);
+
+        $this->assertStringContainsString($expected, $html);
+    }
+
+    /**
+     * @dataProvider dataRegisterLink
+     */
+    public function testRegisterLinkTag(string $expected, ?int $position): void
+    {
+        $webView = TestHelper::createWebView();
+
+        $link = Html::link()->href('/main.css');
+
+        $position === null
+            ? $webView->registerLinkTag($link)
+            : $webView->registerLinkTag($link, $position);
+
+        $html = $webView->render('//positions.php');
+
+        $this->assertStringContainsString($expected, $html);
     }
 
     public function dataRegisterCss(): array

--- a/tests/WebViewTest.php
+++ b/tests/WebViewTest.php
@@ -176,16 +176,31 @@ final class WebViewTest extends TestCase
         $this->assertStringContainsString($signature, $html);
     }
 
-    public function testRegisterMetaTag(): void
+    public function testRegisterMeta(): void
     {
         $webView = TestHelper::createWebView();
 
-        $webView->registerMetaTag([
+        $webView->registerMeta([
             'name' => 'keywords',
             'content' => 'yii',
         ]);
 
         $html = $webView->render('//positions.php');
+
+        $this->assertStringContainsString('[HEAD]<meta name="keywords" content="yii">[/HEAD]', $html);
+    }
+
+    public function testRegisterMetaTag(): void
+    {
+        $webView = TestHelper::createWebView();
+
+        $webView->registerMetaTag(Html::meta([
+            'name' => 'keywords',
+            'content' => 'yii',
+        ]));
+
+        $html = $webView->render('//positions.php');
+
         $this->assertStringContainsString('[HEAD]<meta name="keywords" content="yii">[/HEAD]', $html);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

`WebView::registerMeta()` and `WebView::registerLink()` take arrays.

`WebView::registerMetaTag()` and `WebView::registerLinkTag()` take tag objects from `yiisoft/html`.

Successfully tested with demo application.

Adopt PRs:
https://github.com/yiisoft/yii-view/pull/30
https://github.com/yiisoft/demo/pull/306

