### PR TITLE
Remove `BaseView::withAddedCommonParameters()`, rename "commonParameters" to "parameters", add fluent interface for setters in view classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 3.0.0 under development
 
 - Chg: Remove methods `View::withAddedCommonParameters()` and `WebView::withAddedCommonParameters()` (vjik)
-- Chg: Into classes `View` and `WebView` rename methods `setCommonParameters()` to `setParameters()`, `setCommonParameter()` to `setParameter()`,
+- Сhg: In configuration `params.php` rename parameter `commonParameters` to `parameters` (vjik)
+- Chg: In classes `View` and `WebView` rename methods `setCommonParameters()` to `setParameters()`, `setCommonParameter()` to `setParameter()`,
   `removeCommonParameter()` to `removeParameter()`, `getCommonParameter()` to `getParameter()`,
   `hasCommonParameter()` to `hasParameter()` (vjik)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Chg: In classes `View` and `WebView` rename methods `setCommonParameters()` to `setParameters()`, `setCommonParameter()` to `setParameter()`,
   `removeCommonParameter()` to `removeParameter()`, `getCommonParameter()` to `getParameter()`,
   `hasCommonParameter()` to `hasParameter()` (vjik)
-
+- Chg: Add fluent interface for setters in `View` and `WebView` classes (vjik)
+  
 ## 2.1.0 September 14, 2021
 
 - New #183: Add immutable methods `View::withAddedCommonParameters()` and `WebView::withAddedCommonParameters()` (vjik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 3.0.0 under development
 
-- Chg: Remove methods `View::withAddedCommonParameters()` and `WebView::withAddedCommonParameters()` (vjik) 
+- Chg: Remove methods `View::withAddedCommonParameters()` and `WebView::withAddedCommonParameters()` (vjik)
+- Chg: Into classes `View` and `WebView` rename methods `setCommonParameters()` to `setParameters()`, `setCommonParameter()` to `setParameter()`,
+  `removeCommonParameter()` to `removeParameter()`, `getCommonParameter()` to `getParameter()`,
+  `hasCommonParameter()` to `hasParameter()` (vjik)
 
 ## 2.1.0 September 14, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Yii View Change Log
 
+## 3.0.0 under development
 
-## 2.1.1 under development
-
-- no changes in this release.
+- Chg: Remove methods `View::withAddedCommonParameters()` and `WebView::withAddedCommonParameters()` (vjik) 
 
 ## 2.1.0 September 14, 2021
 

--- a/config/common.php
+++ b/config/common.php
@@ -12,10 +12,12 @@ return [
     View::class => [
         'class' => View::class,
         '__construct()' => [
-            'basePath' => DynamicReference::to(static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])),
+            'basePath' => DynamicReference::to(
+                static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
+            ),
         ],
-        'setCommonParameters()' => [
-            $params['yiisoft/view']['commonParameters'],
+        'setParameters()' => [
+            $params['yiisoft/view']['parameters'],
         ],
         'reset' => function () {
             $this->clear();

--- a/config/params.php
+++ b/config/params.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'yiisoft/view' => [
         'basePath' => '',
-        'commonParameters' => [],
+        'parameters' => [],
         'theme' => [
             'pathMap' => [],
             'basePath' => '',

--- a/config/web.php
+++ b/config/web.php
@@ -27,10 +27,12 @@ return [
     WebView::class => [
         'class' => WebView::class,
         '__construct()' => [
-            'basePath' => DynamicReference::to(static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])),
+            'basePath' => DynamicReference::to(
+                static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
+            ),
         ],
-        'setCommonParameters()' => [
-            $params['yiisoft/view']['commonParameters'],
+        'parameters()' => [
+            $params['yiisoft/view']['parameters'],
         ],
         'reset' => function () {
             $this->clear();

--- a/docs/basic-functionality.md
+++ b/docs/basic-functionality.md
@@ -287,8 +287,8 @@ General parameters are used in the same way, but unlike blocks, the value can be
 This is convenient if you need to set some data that will be available in all views:
 
 ```php
-$view->setCommonParameter('urlGenerator', new MyUrlGenerator());
-$view->setCommonParameter(SomeObject::class, new SomeObject());
+$view->setParameter('urlGenerator', new MyUrlGenerator());
+$view->setParameter(SomeObject::class, new SomeObject());
 
 $view->render('blog/posts');
 ```
@@ -303,11 +303,11 @@ declare(strict_types=1);
 /** @var Yiisoft\View\View $this */
 /** @var App\Blog\Post[] $posts */
 
-$urlGenerator = $this->getCommonParameter('urlGenerator');
+$urlGenerator = $this->getParameter('urlGenerator');
 ?>
 
-<?php if ($this->hasCommonParameter(SomeObject::class)): ?>
-    <?= $this->getCommonParameter(SomeObject::class)->getContent() ?>
+<?php if ($this->hasParameter(SomeObject::class)): ?>
+    <?= $this->getParameter(SomeObject::class)->getContent() ?>
 <?php endif; ?>
 
 Posts:
@@ -319,19 +319,19 @@ Posts:
 <?php endforeach; ?>
 ```
 
-You can not call the `hasCommonParameter()` method, but pass the default value to the `getCommonParameter()` method.
+You can not call the `hasParameter()` method, but pass the default value to the `getParameter()` method.
 At the same time, if the default value is not passed, and the requested parameter does not exist,
 an `InvalidArgumentException` exception will be thrown.
 
 ```php
 // return "default-value"
-$view->getCommonParameter('parameter-name', 'default-value');
+$view->getParameter('parameter-name', 'default-value');
 
 // throw InvalidArgumentException
-$view->getCommonParameter('parameter-name');
+$view->getParameter('parameter-name');
 ```
 
-To delete data, use `removeBlock('id')` and `removeCommonParameter('id')` methods.
+To delete data, use `removeBlock('id')` and `removeParameter('id')` methods.
 
 ## Content caching
 

--- a/src/BaseView.php
+++ b/src/BaseView.php
@@ -206,7 +206,9 @@ abstract class BaseView
     /**
      * Sets a common parameters that is accessible in all view templates.
      *
-     * @param array<string, mixed> $parameters Parameters that are common for all view templates.
+     * @param array $parameters Parameters that are common for all view templates.
+     *
+     * @psalm-param array<string, mixed> $parameters
      *
      * @return static
      *

--- a/src/BaseView.php
+++ b/src/BaseView.php
@@ -208,14 +208,17 @@ abstract class BaseView
      *
      * @param array<string, mixed> $parameters Parameters that are common for all view templates.
      *
+     * @return static
+     *
      * @see setParameter()
      */
-    public function setParameters(array $parameters): void
+    public function setParameters(array $parameters): self
     {
         /** @var mixed $value */
         foreach ($parameters as $id => $value) {
             $this->setParameter($id, $value);
         }
+        return $this;
     }
 
     /**
@@ -223,10 +226,13 @@ abstract class BaseView
      *
      * @param string $id The unique identifier of the parameter.
      * @param mixed $value The value of the parameter.
+     *
+     * @return static
      */
-    public function setParameter(string $id, $value): void
+    public function setParameter(string $id, $value): self
     {
         $this->parameters[$id] = $value;
+        return $this;
     }
 
     /**
@@ -280,10 +286,13 @@ abstract class BaseView
      *
      * @param string $id The unique identifier of the block.
      * @param string $content The content of the block.
+     *
+     * @return static
      */
-    public function setBlock(string $id, string $content): void
+    public function setBlock(string $id, string $content): self
     {
         $this->blocks[$id] = $content;
+        return $this;
     }
 
     /**
@@ -349,10 +358,13 @@ abstract class BaseView
      * Sets a salt for the placeholder signature {@see getPlaceholderSignature()}.
      *
      * @param string $salt The placeholder salt.
+     *
+     * @return static
      */
-    final public function setPlaceholderSalt(string $salt): void
+    final public function setPlaceholderSalt(string $salt): self
     {
         $this->placeholderSignature = dechex(crc32($salt));
+        return $this;
     }
 
     /**

--- a/src/BaseView.php
+++ b/src/BaseView.php
@@ -51,7 +51,7 @@ abstract class BaseView
      * @var array Parameters that are common for all view templates.
      * @psalm-var array<string, mixed>
      */
-    private array $commonParameters = [];
+    private array $parameters = [];
 
     /**
      * @var array Named content blocks that are common for all view templates.
@@ -206,15 +206,15 @@ abstract class BaseView
     /**
      * Sets a common parameters that is accessible in all view templates.
      *
-     * @param array<string, mixed> $commonParameters Parameters that are common for all view templates.
+     * @param array<string, mixed> $parameters Parameters that are common for all view templates.
      *
-     * @see setCommonParameter()
+     * @see setParameter()
      */
-    public function setCommonParameters(array $commonParameters): void
+    public function setParameters(array $parameters): void
     {
         /** @var mixed $value */
-        foreach ($commonParameters as $id => $value) {
-            $this->setCommonParameter($id, $value);
+        foreach ($parameters as $id => $value) {
+            $this->setParameter($id, $value);
         }
     }
 
@@ -224,9 +224,9 @@ abstract class BaseView
      * @param string $id The unique identifier of the parameter.
      * @param mixed $value The value of the parameter.
      */
-    public function setCommonParameter(string $id, $value): void
+    public function setParameter(string $id, $value): void
     {
-        $this->commonParameters[$id] = $value;
+        $this->parameters[$id] = $value;
     }
 
     /**
@@ -234,9 +234,9 @@ abstract class BaseView
      *
      * @param string $id The unique identifier of the parameter.
      */
-    public function removeCommonParameter(string $id): void
+    public function removeParameter(string $id): void
     {
-        unset($this->commonParameters[$id]);
+        unset($this->parameters[$id]);
     }
 
     /**
@@ -249,10 +249,10 @@ abstract class BaseView
      *
      * @return mixed The value of the parameter.
      */
-    public function getCommonParameter(string $id)
+    public function getParameter(string $id)
     {
-        if (isset($this->commonParameters[$id])) {
-            return $this->commonParameters[$id];
+        if (isset($this->parameters[$id])) {
+            return $this->parameters[$id];
         }
 
         $args = func_get_args();
@@ -270,9 +270,9 @@ abstract class BaseView
      *
      * @return bool Whether a custom parameter that is common for all view templates exists.
      */
-    public function hasCommonParameter(string $id): bool
+    public function hasParameter(string $id): bool
     {
-        return isset($this->commonParameters[$id]);
+        return isset($this->parameters[$id]);
     }
 
     /**
@@ -405,7 +405,7 @@ abstract class BaseView
      */
     public function renderFile(string $viewFile, array $parameters = []): string
     {
-        $parameters = array_merge($this->commonParameters, $parameters);
+        $parameters = array_merge($this->parameters, $parameters);
 
         // TODO: these two match now
         $requestedFile = $viewFile;

--- a/src/BaseView.php
+++ b/src/BaseView.php
@@ -204,22 +204,6 @@ abstract class BaseView
     }
 
     /**
-     * Returns a new instance with the appended a common parameters that is accessible in all view templates.
-     *
-     * @param array $commonParameters Parameters that are common for all view templates.
-     *
-     * @psalm-param array<string, mixed> $commonParameters
-     *
-     * @return static
-     */
-    public function withAddedCommonParameters(array $commonParameters): self
-    {
-        $new = clone $this;
-        $new->setCommonParameters($commonParameters);
-        return $new;
-    }
-
-    /**
      * Sets a common parameters that is accessible in all view templates.
      *
      * @param array<string, mixed> $commonParameters Parameters that are common for all view templates.

--- a/src/PhpTemplateRenderer.php
+++ b/src/PhpTemplateRenderer.php
@@ -19,7 +19,7 @@ use function ob_start;
  */
 final class PhpTemplateRenderer implements TemplateRendererInterface
 {
-    public function render(BaseView $view, string $template, array $params): string
+    public function render(BaseView $view, string $template, array $parameters): string
     {
         $renderer = function (): void {
             /** @psalm-suppress MixedArgument */
@@ -34,7 +34,7 @@ final class PhpTemplateRenderer implements TemplateRendererInterface
         PHP_VERSION_ID >= 80000 ? ob_implicit_flush(false) : ob_implicit_flush(0);
         try {
             /** @psalm-suppress PossiblyInvalidFunctionCall */
-            $renderer->bindTo($view)($template, $params);
+            $renderer->bindTo($view)($template, $parameters);
             return ob_get_clean();
         } catch (Throwable $e) {
             while (ob_get_level() > $obInitialLevel) {

--- a/src/TemplateRendererInterface.php
+++ b/src/TemplateRendererInterface.php
@@ -17,9 +17,9 @@ interface TemplateRendererInterface
      *
      * @param BaseView|View|WebView $view The view instance used for rendering the file.
      * @param string $template The template file.
-     * @param array $params The parameters to be passed to the view file.
+     * @param array $parameters The parameters to be passed to the view file.
      *
      * @return string The rendering result.
      */
-    public function render(BaseView $view, string $template, array $params): string;
+    public function render(BaseView $view, string $template, array $parameters): string;
 }

--- a/src/WebView.php
+++ b/src/WebView.php
@@ -629,10 +629,13 @@ final class WebView extends BaseView
      * {@see getTitle()}
      *
      * @param string $value
+     *
+     * @return static
      */
-    public function setTitle(string $value): void
+    public function setTitle(string $value): self
     {
         $this->title = $value;
+        return $this;
     }
 
     protected function createBeforeRenderEvent(string $viewFile, array $parameters): StoppableEventInterface

--- a/src/WebView.php
+++ b/src/WebView.php
@@ -211,14 +211,14 @@ final class WebView extends BaseView
      * view.
      *
      * @param string $view The view name. Please refer to {@see render()} on how to specify this parameter.
-     * @param array $params The parameters (name-value pairs) that will be extracted and made available in the view
+     * @param array $parameters The parameters (name-value pairs) that will be extracted and made available in the view
      * file.
      *
      * @return string The rendering result
      *
      * {@see render()}
      */
-    public function renderAjax(string $view, array $params = []): string
+    public function renderAjax(string $view, array $parameters = []): string
     {
         $viewFile = $this->findTemplateFile($view);
 
@@ -229,7 +229,7 @@ final class WebView extends BaseView
         $this->beginPage();
         $this->head();
         $this->beginBody();
-        echo $this->renderFile($viewFile, $params);
+        echo $this->renderFile($viewFile, $parameters);
         $this->endBody();
         $this->endPage(true);
 

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -236,46 +236,46 @@ PHP
         );
     }
 
-    public function testCommonParameter(): void
+    public function testParameter(): void
     {
         $view = TestHelper::createView();
-        $this->assertFalse($view->hasCommonParameter('id'));
+        $this->assertFalse($view->hasParameter('id'));
 
-        $view->setCommonParameters(['id' => 0]);
-        $this->assertTrue($view->hasCommonParameter('id'));
-        $this->assertSame(0, $view->getCommonParameter('id'));
+        $view->setParameters(['id' => 0]);
+        $this->assertTrue($view->hasParameter('id'));
+        $this->assertSame(0, $view->getParameter('id'));
 
-        $view->setCommonParameter('id', 42);
-        $this->assertTrue($view->hasCommonParameter('id'));
-        $this->assertSame(42, $view->getCommonParameter('id'));
+        $view->setParameter('id', 42);
+        $this->assertTrue($view->hasParameter('id'));
+        $this->assertSame(42, $view->getParameter('id'));
 
-        $view->removeCommonParameter('id');
-        $this->assertFalse($view->hasCommonParameter('id'));
+        $view->removeParameter('id');
+        $this->assertFalse($view->hasParameter('id'));
 
         $this->expectException(InvalidArgumentException::class);
-        $view->getCommonParameter('id');
+        $view->getParameter('id');
     }
 
-    public function testCommonParameterDefaultValue(): void
+    public function testParameterDefaultValue(): void
     {
         $view = TestHelper::createView();
 
-        $this->assertSame(42, $view->getCommonParameter('id', 42));
+        $this->assertSame(42, $view->getParameter('id', 42));
     }
 
-    public function testCommonParameterIsPassedToView(): void
+    public function testParameterIsPassedToView(): void
     {
         $view = TestHelper::createView();
-        $view->setCommonParameter('parameter', 'global-parameter');
+        $view->setParameter('parameter', 'global-parameter');
         $output = $view->render('//parameters');
 
         $this->assertSame('global-parameter', $output);
     }
 
-    public function testCommonParameterIsOverwrittenByLocalParameter(): void
+    public function testViewParameterIsOverwrittenByRenderParameter(): void
     {
         $view = TestHelper::createView();
-        $view->setCommonParameter('parameter', 'global-parameter');
+        $view->setParameter('parameter', 'global-parameter');
 
         $output = $view->render('//parameters', [
             'parameter' => 'local-parameter',

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -163,8 +163,7 @@ PHP
     public function testRenderWithoutFileExtension(): void
     {
         $view = $this->createViewWithBasePath($this->tempDirectory)
-            ->withContext($this->createContext($this->tempDirectory))
-        ;
+            ->withContext($this->createContext($this->tempDirectory));
         file_put_contents("$this->tempDirectory/file.php", 'Test');
         file_put_contents("$this->tempDirectory/file.tpl", 'Test');
         file_put_contents("$this->tempDirectory/file.txt.php", 'Test');
@@ -324,6 +323,16 @@ PHP
             PageBegin::class,
             PageEnd::class,
         ], $eventDispatcher->getEventClasses());
+    }
+
+    public function testFluentSetters(): void
+    {
+        $view = TestHelper::createView();
+
+        $this->assertSame($view, $view->setBlock('test', ''));
+        $this->assertSame($view, $view->setParameter('test', ''));
+        $this->assertSame($view, $view->setParameters([]));
+        $this->assertSame($view, $view->setPlaceholderSalt(''));
     }
 
     public function testImmutability(): void

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -256,17 +256,6 @@ PHP
         $view->getCommonParameter('id');
     }
 
-    public function testWithAddedCommonParameters(): void
-    {
-        $view = TestHelper::createView();
-        $view->setCommonParameters(['a' => 1, 'b' => 2]);
-        $view = $view->withAddedCommonParameters(['b' => 12, 'c' => 13]);
-
-        $this->assertSame(1, $view->getCommonParameter('a'));
-        $this->assertSame(12, $view->getCommonParameter('b'));
-        $this->assertSame(13, $view->getCommonParameter('c'));
-    }
-
     public function testCommonParameterDefaultValue(): void
     {
         $view = TestHelper::createView();
@@ -347,7 +336,6 @@ PHP
         $this->assertNotSame($view, $view->withSourceLanguage('en'));
         $this->assertNotSame($view, $view->withDefaultExtension('php'));
         $this->assertNotSame($view, $view->withContext($this->createContext($this->tempDirectory)));
-        $this->assertNotSame($view, $view->withAddedCommonParameters([]));
     }
 
     private function createViewWithBasePath(string $basePath): View

--- a/tests/WebViewTest.php
+++ b/tests/WebViewTest.php
@@ -742,4 +742,15 @@ final class WebViewTest extends TestCase
         $view->setTitle('test');
         $this->assertSame('test', $view->getTitle());
     }
+
+    public function testFluentSetters(): void
+    {
+        $view = TestHelper::createWebView();
+
+        $this->assertSame($view, $view->setTitle(''));
+        $this->assertSame($view, $view->setBlock('test', ''));
+        $this->assertSame($view, $view->setParameter('test', ''));
+        $this->assertSame($view, $view->setParameters([]));
+        $this->assertSame($view, $view->setPlaceholderSalt(''));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

Adopt PRs: https://github.com/yiisoft/app/pull/194 and https://github.com/yiisoft/demo/pull/355

Tests in `yiisoft/app-api` and `yiisoft/demo-api` is passed.