### PR TITLE
Add simple view context class `ViewContext` and methods `View::withContextPath()` and `WebView::withContextPath()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Yii View Change Log
 
+## 4.1.0 under development
 
-## 4.0.1 under development
-
-- no changes in this release.
+- New #193: Add simple view context class `ViewContext` (vjik)
 
 ## 4.0.0 October 25, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.1.0 under development
 
 - New #193: Add simple view context class `ViewContext` (vjik)
+- New #193: Add methods `View::withContextPath()` and `WebView::withContextPath()` that set view context path (vjik)
 
 ## 4.0.0 October 25, 2021
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "phpunit/phpunit": "^9.5",
         "roave/infection-static-analysis-plugin": "^1.10",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.10",
+        "vimeo/psalm": "^4.12",
         "yiisoft/aliases": "^2.0",
         "yiisoft/psr-dummy-provider": "^1.0",
         "yiisoft/test-support": "^1.3"

--- a/src/ViewContext.php
+++ b/src/ViewContext.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View;
+
+final class ViewContext implements ViewContextInterface
+{
+    private string $viewPath;
+
+    public function __construct(string $viewPath)
+    {
+        $this->viewPath = $viewPath;
+    }
+
+    public function getViewPath(): string
+    {
+        return $this->viewPath;
+    }
+}

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -177,6 +177,18 @@ trait ViewTrait
     }
 
     /**
+     * Returns a new instance with the specified view context path.
+     *
+     * @param string $path The context path under which the {@see renderFile()} method is being invoked.
+     *
+     * @return static
+     */
+    public function withContextPath(string $path): self
+    {
+        return $this->withContext(new ViewContext($path));
+    }
+
+    /**
      * Gets the base path to the view directory.
      *
      * @return string The base view path.

--- a/tests/ViewContextTest.php
+++ b/tests/ViewContextTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\View\ViewContext;
+
+final class ViewContextTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $context = new ViewContext(__DIR__);
+
+        $this->assertSame(__DIR__, $context->getViewPath());
+    }
+}

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -160,6 +160,15 @@ PHP
         $this->assertSame($subViewContent, $view->render('test/base'));
     }
 
+    public function testWithContextPath(): void
+    {
+        $view = TestHelper::createView()->withContextPath(
+            __DIR__ . '/public/view/custom-context'
+        );
+
+        $this->assertSame('42', $view->render('view'));
+    }
+
     public function testFlushViewFilesOnChangeContext(): void
     {
         $view = TestHelper::createView();
@@ -370,6 +379,7 @@ PHP
         $this->assertNotSame($view, $view->withSourceLanguage('en'));
         $this->assertNotSame($view, $view->withDefaultExtension('php'));
         $this->assertNotSame($view, $view->withContext($this->createContext($this->tempDirectory)));
+        $this->assertNotSame($view, $view->withContextPath(__DIR__));
     }
 
     private function createViewWithBasePath(string $basePath): View


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

For example, this class convient use in widgets:

```php
final class SidebarMenu extends Widget
{
    public function __construct(
        private View $view
    ) {
        $this->view = $this->view->withContext(new ViewContext(__DIR__));
    }

    protected function run(): string
    {
        return $this->view->render('menu');
    }
}
```

or so:

```php
final class SidebarMenu extends Widget
{
    public function __construct(
        private View $view
    ) {
        $this->view = $this->view->withContextPath(__DIR__);
    }

    protected function run(): string
    {
        return $this->view->render('menu');
    }
}
```

This is better, than:

```php
final class SidebarMenu extends Widget implements ViewContextInterface
{
    public function __construct(
        private View $view
    ) {
        $this->view = $this->view->withContext($this);
    }

    protected function run(): string
    {
        return $this->view->render('menu');
    }

    public function getViewPath(): string
    {
        return __DIR__;
    }
}
```