### PR TITLE
Add `ViewTrait::addToArrayParameter()` and more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - New #193: Add simple view context class `ViewContext` (vjik)
 - New #193: Add methods `View::withContextPath()` and `WebView::withContextPath()` that set view context path (vjik)
-- New #194: Add methods `View::addToArrayParameter()` and `WebView::addToArrayParameter()` that add value(s)
-  to end of specified array parameter (vjik)
+- New #194: Add methods `View::addToParameter()` and `WebView::addToParameter()` that add value(s) to end of
+  specified array parameter (vjik)
 
 ## 4.0.0 October 25, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - New #193: Add simple view context class `ViewContext` (vjik)
 - New #193: Add methods `View::withContextPath()` and `WebView::withContextPath()` that set view context path (vjik)
+- New #194: Add methods `View::addToArrayParameter()` and `WebView::addToArrayParameter()` that add value(s)
+  to end of specified array parameter (vjik)
 
 ## 4.0.0 October 25, 2021
 

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -262,7 +262,7 @@ trait ViewTrait
      *
      * @return static
      */
-    public function addToArrayParameter(string $id, ...$value): self
+    public function addToParameter(string $id, ...$value): self
     {
         /** @var mixed $array */
         $array = $this->parameters[$id] ?? [];

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -254,8 +254,11 @@ trait ViewTrait
     }
 
     /**
+     * Add values to end of common array parameter. If specified parameter does not exist or him is not array,
+     * then parameter will be added as empty array.
+     *
      * @param string $id The unique identifier of the parameter.
-     * @param mixed ...$value
+     * @param mixed ...$value Value(s) for add to end of array parameter.
      *
      * @return static
      */

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -260,6 +260,8 @@ trait ViewTrait
      * @param string $id The unique identifier of the parameter.
      * @param mixed ...$value Value(s) for add to end of array parameter.
      *
+     * @throws InvalidArgumentException When specified parameter already exists and is not an array.
+     *
      * @return static
      */
     public function addToParameter(string $id, ...$value): self
@@ -267,7 +269,9 @@ trait ViewTrait
         /** @var mixed $array */
         $array = $this->parameters[$id] ?? [];
         if (!is_array($array)) {
-            $array = [];
+            throw new InvalidArgumentException(
+                sprintf('The "%s" parameter already exists and is not an array.', $id)
+            );
         }
 
         $this->setParameter($id, array_merge($array, $value));

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -21,6 +21,7 @@ use function dechex;
 use function dirname;
 use function end;
 use function func_get_args;
+use function is_array;
 use function is_file;
 use function pathinfo;
 use function substr;
@@ -249,6 +250,25 @@ trait ViewTrait
     public function setParameter(string $id, $value): self
     {
         $this->parameters[$id] = $value;
+        return $this;
+    }
+
+    /**
+     * @param string $id The unique identifier of the parameter.
+     * @param mixed ...$value
+     *
+     * @return static
+     */
+    public function addToArrayParameter(string $id, ...$value): self
+    {
+        /** @var mixed $array */
+        $array = $this->parameters[$id] ?? [];
+        if (!is_array($array)) {
+            $array = [];
+        }
+
+        $this->setParameter($id, array_merge($array, $value));
+
         return $this;
     }
 

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -408,6 +408,20 @@ PHP
         $this->assertSame($view, $view->setPlaceholderSalt(''));
     }
 
+    public function testClear(): void
+    {
+        $view = TestHelper::createView();
+
+        try {
+            $view->renderFile(__DIR__ . '/public/view/error.php');
+        } catch (Exception $e) {
+        }
+
+        $view->clear();
+
+        $this->assertNull($view->getViewFile());
+    }
+
     public function testImmutability(): void
     {
         $view = TestHelper::createView();

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -278,6 +278,44 @@ PHP
         $this->assertSame(42, $view->getParameter('id', 42));
     }
 
+    public function testAddToArrayParameter(): void
+    {
+        $view = TestHelper::createView();
+
+        $view->addToArrayParameter('test', 'a');
+
+        $this->assertSame(['a'], $view->getParameter('test'));
+    }
+
+    public function testAddToArrayParameterWithVaridicValues(): void
+    {
+        $view = TestHelper::createView();
+
+        $view->addToArrayParameter('test', 'a', 'b', 'c');
+
+        $this->assertSame(['a', 'b', 'c'], $view->getParameter('test'));
+    }
+
+    public function testAddToArrayParameterSeveral(): void
+    {
+        $view = TestHelper::createView();
+
+        $view->addToArrayParameter('test', 'a');
+        $view->addToArrayParameter('test', 'b', 'c');
+
+        $this->assertSame(['a', 'b', 'c'], $view->getParameter('test'));
+    }
+
+    public function testAddToArrayParameterWithNotArray(): void
+    {
+        $view = TestHelper::createView();
+
+        $view->setParameter('test', 42);
+        $view->addToArrayParameter('test', 'a', 'b');
+
+        $this->assertSame(['a', 'b'], $view->getParameter('test'));
+    }
+
     public function testGetNotExistParameter(): void
     {
         $view = TestHelper::createView();
@@ -366,6 +404,7 @@ PHP
         $this->assertSame($view, $view->setBlock('test', ''));
         $this->assertSame($view, $view->setParameter('test', ''));
         $this->assertSame($view, $view->setParameters([]));
+        $this->assertSame($view, $view->addToArrayParameter('test'));
         $this->assertSame($view, $view->setPlaceholderSalt(''));
     }
 

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -311,9 +311,10 @@ PHP
         $view = TestHelper::createView();
 
         $view->setParameter('test', 42);
-        $view->addToParameter('test', 'a', 'b');
 
-        $this->assertSame(['a', 'b'], $view->getParameter('test'));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "test" parameter already exists and is not an array.');
+        $view->addToParameter('test', 'a', 'b');
     }
 
     public function testGetNotExistParameter(): void
@@ -404,7 +405,7 @@ PHP
         $this->assertSame($view, $view->setBlock('test', ''));
         $this->assertSame($view, $view->setParameter('test', ''));
         $this->assertSame($view, $view->setParameters([]));
-        $this->assertSame($view, $view->addToParameter('test'));
+        $this->assertSame($view, $view->addToParameter('test-array'));
         $this->assertSame($view, $view->setPlaceholderSalt(''));
     }
 

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -278,40 +278,40 @@ PHP
         $this->assertSame(42, $view->getParameter('id', 42));
     }
 
-    public function testAddToArrayParameter(): void
+    public function testAddToParameter(): void
     {
         $view = TestHelper::createView();
 
-        $view->addToArrayParameter('test', 'a');
+        $view->addToParameter('test', 'a');
 
         $this->assertSame(['a'], $view->getParameter('test'));
     }
 
-    public function testAddToArrayParameterWithVaridicValues(): void
+    public function testAddToParameterWithVaridicValues(): void
     {
         $view = TestHelper::createView();
 
-        $view->addToArrayParameter('test', 'a', 'b', 'c');
+        $view->addToParameter('test', 'a', 'b', 'c');
 
         $this->assertSame(['a', 'b', 'c'], $view->getParameter('test'));
     }
 
-    public function testAddToArrayParameterSeveral(): void
+    public function testAddToParameterSeveral(): void
     {
         $view = TestHelper::createView();
 
-        $view->addToArrayParameter('test', 'a');
-        $view->addToArrayParameter('test', 'b', 'c');
+        $view->addToParameter('test', 'a');
+        $view->addToParameter('test', 'b', 'c');
 
         $this->assertSame(['a', 'b', 'c'], $view->getParameter('test'));
     }
 
-    public function testAddToArrayParameterWithNotArray(): void
+    public function testAddToParameterWithNotArray(): void
     {
         $view = TestHelper::createView();
 
         $view->setParameter('test', 42);
-        $view->addToArrayParameter('test', 'a', 'b');
+        $view->addToParameter('test', 'a', 'b');
 
         $this->assertSame(['a', 'b'], $view->getParameter('test'));
     }
@@ -404,7 +404,7 @@ PHP
         $this->assertSame($view, $view->setBlock('test', ''));
         $this->assertSame($view, $view->setParameter('test', ''));
         $this->assertSame($view, $view->setParameters([]));
-        $this->assertSame($view, $view->addToArrayParameter('test'));
+        $this->assertSame($view, $view->addToParameter('test'));
         $this->assertSame($view, $view->setPlaceholderSalt(''));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

For example, this method will be useful for breadcrumbs: 

```php
// Add in view
$this->addToArrayParameter('breadcrumbs', $item1, $item2);

// Get in layout
$breadcrumbs = $this->getParameter('breadcrumbs') ?? [];
```
