### PR TITLE
Add `getLocale()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Chg #232: Deprecate `ViewInterface::withDefaultExtension()` and `ViewInterface::getDefaultExtension()` in favor of 
   `withFallbackExtension()` and `getFallbackExtensions()` (@rustamwin)
 - Bug #232: Fix render templates that contain dots in their name (@rustamwin)
-- Enh #242: Add `ViewTrait::getLocale()` method (@Tigrov)
+- Enh #242: Add `View::getLocale()` and `WebView::getLocale()` methods (@Tigrov)
 
 ## 8.0.0 February 16, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Chg #232: Deprecate `ViewInterface::withDefaultExtension()` and `ViewInterface::getDefaultExtension()` in favor of 
   `withFallbackExtension()` and `getFallbackExtensions()` (@rustamwin)
 - Bug #232: Fix render templates that contain dots in their name (@rustamwin)
-- Enh #242: Add `View::getLocale()` and `WebView::getLocale()` methods (@Tigrov)
+- New #242: Add `View::getLocale()` and `WebView::getLocale()` methods (@Tigrov)
 
 ## 8.0.0 February 16, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Chg #232: Deprecate `ViewInterface::withDefaultExtension()` and `ViewInterface::getDefaultExtension()` in favor of 
   `withFallbackExtension()` and `getFallbackExtensions()` (@rustamwin)
 - Bug #232: Fix render templates that contain dots in their name (@rustamwin)
+- Enh #242: Add `ViewTrait::getLocale()` method (@Tigrov)
 
 ## 8.0.0 February 16, 2023
 

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -97,6 +97,13 @@ interface ViewInterface
     public function withLocale(string $locale): static;
 
     /**
+     * Get the specified locale code.
+     *
+     * @return string The locale code.
+     */
+    public function getLocale(): string;
+
+    /**
      * Gets the base path to the view directory.
      *
      * @return string The base view path.

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -190,6 +190,16 @@ trait ViewTrait
     }
 
     /**
+     * Get the specified locale code.
+     *
+     * @return string The locale code.
+     */
+    public function getLocale(): string
+    {
+        return $this->localeState->getLocale();
+    }
+
+    /**
      * Gets the base path to the view directory.
      *
      * @return string The base view path.

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -586,6 +586,17 @@ PHP
         $this->assertNotSame($view, $view->withFallbackExtension('tpl'));
     }
 
+    public function testGetLocale()
+    {
+        $view = TestHelper::createView();
+
+        $this->assertSame('en', $view->getLocale());
+
+        $view->setLocale('en-US');
+
+        $this->assertSame('en-US', $view->getLocale());
+    }
+
     private function createViewWithBasePath(string $basePath): View
     {
         return new View($basePath, new SimpleEventDispatcher());


### PR DESCRIPTION
It needs to get current locale when page is rendering

`<html lang="<?= Html::encode($view->getLocale()) ?>">`

Also this will allow fix issue yiisoft/app#290

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
