### PR TITLE
Allow to pass `null` to `ViewInterface` methods `withBasePath()` and `withContext()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 11.0.2 under development
 
-- no changes in this release.
+- Chg #276: Allow to pass `null` to `ViewInterface` methods `withBasePath()` and `withContext()` (@vjik) 
 
 ## 11.0.1 October 08, 2024
 

--- a/src/ViewInterface.php
+++ b/src/ViewInterface.php
@@ -19,9 +19,9 @@ interface ViewInterface
     /**
      * Returns a new instance with specified base path to the view directory.
      *
-     * @param string $basePath The base path to the view directory.
+     * @param string|null $basePath The base path to the view directory.
      */
-    public function withBasePath(string $basePath): static;
+    public function withBasePath(string|null $basePath): static;
 
     /**
      * Returns a new instance with the specified renderers.
@@ -50,9 +50,9 @@ interface ViewInterface
     /**
      * Returns a new instance with the specified view context instance.
      *
-     * @param ViewContextInterface $context The context under which the {@see render()} method is being invoked.
+     * @param ViewContextInterface|null $context The context under which the {@see render()} method is being invoked.
      */
-    public function withContext(ViewContextInterface $context): static;
+    public function withContext(ViewContextInterface|null $context): static;
 
     /**
      * Returns a new instance with the specified view context path.

--- a/src/ViewTrait.php
+++ b/src/ViewTrait.php
@@ -62,9 +62,9 @@ trait ViewTrait
     /**
      * Returns a new instance with specified base path to the view directory.
      *
-     * @param string $basePath The base path to the view directory.
+     * @param string|null $basePath The base path to the view directory.
      */
-    public function withBasePath(string $basePath): static
+    public function withBasePath(string|null $basePath): static
     {
         $new = clone $this;
         $new->basePath = $basePath;
@@ -121,9 +121,9 @@ trait ViewTrait
     /**
      * Returns a new instance with the specified view context instance.
      *
-     * @param ViewContextInterface $context The context under which the {@see render()} method is being invoked.
+     * @param ViewContextInterface|null $context The context under which the {@see render()} method is being invoked.
      */
-    public function withContext(ViewContextInterface $context): static
+    public function withContext(ViewContextInterface|null $context): static
     {
         $new = clone $this;
         $new->context = $context;

--- a/tests/View/ResetContext/ResetContextTest.php
+++ b/tests/View/ResetContext/ResetContextTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\View\Tests\View\ResetContext;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\View\View;
+use Yiisoft\View\ViewContext;
+
+final class ResetContextTest extends TestCase
+{
+    public function testBase(): void
+    {
+        $baseView = (new View(__DIR__.'/views-base'))
+            ->withContext(new ViewContext(__DIR__.'/views-context'));
+
+        $view = $baseView->withContext(null);
+
+        $baseContent = $baseView->render('test');
+        $content = $view->render('test');
+
+        $this->assertSame('View Context', $baseContent);
+        $this->assertSame('View Base', $content);
+    }
+}

--- a/tests/View/ResetContext/ResetContextTest.php
+++ b/tests/View/ResetContext/ResetContextTest.php
@@ -12,8 +12,8 @@ final class ResetContextTest extends TestCase
 {
     public function testBase(): void
     {
-        $baseView = (new View(__DIR__.'/views-base'))
-            ->withContext(new ViewContext(__DIR__.'/views-context'));
+        $baseView = (new View(__DIR__ . '/views-base'))
+            ->withContext(new ViewContext(__DIR__ . '/views-context'));
 
         $view = $baseView->withContext(null);
 

--- a/tests/View/ResetContext/views-base/test.php
+++ b/tests/View/ResetContext/views-base/test.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+echo 'View Base';

--- a/tests/View/ResetContext/views-context/test.php
+++ b/tests/View/ResetContext/views-context/test.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+echo 'View Context';

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -614,6 +614,19 @@ PHP
         $view->getBasePath();
     }
 
+    public function testResetBasePath(): void
+    {
+        $baseView = new View(__DIR__);
+
+        $view = $baseView->withBasePath(null);
+
+        $this->assertSame(__DIR__, $baseView->getBasePath());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The base path is not set.');
+        $view->getBasePath();
+    }
+
     private function createViewWithBasePath(string $basePath): View
     {
         return new View($basePath, new SimpleEventDispatcher());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

