### PR TITLE
Fix `di-web` for theme `pathMap` configuration with multiple paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.1.1 under development
 
 - New #284: Allow to pass `Stringable` objects to `WebView::setTitle()` method (@vjik)
+- Bug #283: Allow using multiple theme paths in `yiisoft/view → theme → pathMap` package parameter (@mariovials, @vjik)  
 
 ## 12.1.0 March 15, 2025
 

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -16,11 +16,9 @@ return [
         $pathMap = [];
 
         foreach ($params['yiisoft/view']['theme']['pathMap'] as $key => $value) {
-            if (is_array($value)) {
-                $pathMap[$aliases->get($key)] = $aliases->getArray($value);
-            } else {
-                $pathMap[$aliases->get($key)] = $aliases->get($value);
-            }
+            $pathMap[$aliases->get($key)] = is_array($value)
+                ? $aliases->getArray($value)
+                : $aliases->get($value);
         }
 
         return new Theme(

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -17,7 +17,7 @@ return [
 
         foreach ($params['yiisoft/view']['theme']['pathMap'] as $key => $value) {
             if (is_array($value)) {
-                $pathMap[$aliases->get($key)] = array_map([$aliases, 'get'], $value);
+                $pathMap[$aliases->get($key)] = $aliases->getArray($value);
             } else {
                 $pathMap[$aliases->get($key)] = $aliases->get($value);
             }

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -17,9 +17,9 @@ return [
 
         foreach ($params['yiisoft/view']['theme']['pathMap'] as $key => $value) {
             if (is_array($value)) {
-              $pathMap[$aliases->get($key)] = array_map([$aliases, 'get'], $value);
+                $pathMap[$aliases->get($key)] = array_map([$aliases, 'get'], $value);
             } else {
-              $pathMap[$aliases->get($key)] = $aliases->get($value);
+                $pathMap[$aliases->get($key)] = $aliases->get($value);
             }
         }
 

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -16,7 +16,11 @@ return [
         $pathMap = [];
 
         foreach ($params['yiisoft/view']['theme']['pathMap'] as $key => $value) {
-            $pathMap[$aliases->get($key)] = $aliases->get($value);
+            if (is_array($value)) {
+              $pathMap[$aliases->get($key)] = array_map([$aliases, 'get'], $value);
+            } else {
+              $pathMap[$aliases->get($key)] = $aliases->get($value);
+            }
         }
 
         return new Theme(

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -61,6 +61,23 @@ final class ConfigTest extends TestCase
         $this->assertInstanceOf(WebView::class, $webView);
     }
 
+    public function testDiWebWithPathMap(): void
+    {
+        $params = $this->getParams();
+        $params['yiisoft/view']['theme']['pathMap'] = [
+            '/app/module/views' => 'app/themes/module/basic',
+            '/app/views' => [
+                '/app/themes/christmas',
+                '/app/themes/basic',
+            ],
+        ];
+        $container = $this->createContainer('web', $params);
+
+        $theme = $container->get(Theme::class);
+
+        $this->assertInstanceOf(Theme::class, $theme);
+    }
+
     private function createContainer(?string $postfix = null, ?array $params = null): Container
     {
         return new Container(


### PR DESCRIPTION
Allows you to use a directory array as the source of the view files, as described in the documentation of the Theme class

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Without this, when configuring a theme with multiple paths, the following error occurs
![image](https://github.com/user-attachments/assets/1d90a8cc-fdfb-4945-9e1c-e8185b49c299)

```
'yiisoft/view' => [
    'theme' => [
        'pathMap' => [
            '/app/views' => [
                '/app/themes/christmas',
                '/app/themes/basic',
            ],
        ],
        ...
    ],
],
```
now you can set up a theme as described in the Theme documentation, for multiple cascading directories, as this is the main functionality of Theme