### PR TITLE
Allow to use `null` as value of `basePath` parameter in package configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 12.2.1 under development
 
-- no changes in this release.
+- Enh #286: Allow to use `null` as value of `basePath` parameter in package configuration (@vjik)
 
 ## 12.2.0 May 16, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -36,13 +36,13 @@
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.7.1",
-        "phpunit/phpunit": "^10.5.46",
-        "rector/rector": "^2.0.16",
+        "phpunit/phpunit": "^10.5.48",
+        "rector/rector": "^2.1.2",
         "roave/infection-static-analysis-plugin": "^1.35",
         "spatie/phpunit-watcher": "^1.24",
         "vimeo/psalm": "^5.26.1 || ^6.8.9",
         "yiisoft/aliases": "^3.0",
-        "yiisoft/di": "^1.3",
+        "yiisoft/di": "^1.4",
         "yiisoft/psr-dummy-provider": "^1.0.2",
         "yiisoft/test-support": "^3.0.2"
     },

--- a/config/di-web.php
+++ b/config/di-web.php
@@ -30,9 +30,11 @@ return [
 
     WebView::class => [
         '__construct()' => [
-            'basePath' => DynamicReference::to(
-                static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
-            ),
+            'basePath' => $params['yiisoft/view']['basePath'] === null
+                ? null
+                : DynamicReference::to(
+                    static fn(Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
+                ),
         ],
         'setParameters()' => [$params['yiisoft/view']['parameters']],
         'withRenderers()' => [$params['yiisoft/view']['renderers']],

--- a/config/di.php
+++ b/config/di.php
@@ -13,9 +13,11 @@ use Yiisoft\View\View;
 return [
     View::class => [
         '__construct()' => [
-            'basePath' => DynamicReference::to(
-                static fn (Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
-            ),
+            'basePath' => $params['yiisoft/view']['basePath'] === null
+                ? null
+                : DynamicReference::to(
+                    static fn(Aliases $aliases) => $aliases->get($params['yiisoft/view']['basePath'])
+                ),
         ],
         'setParameters()' => [$params['yiisoft/view']['parameters']],
         'withRenderers()' => [$params['yiisoft/view']['renderers']],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

