### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    # Too noisy. See https://github.community/t/increase-if-necessary-for-github-actions-in-dependabot/179581
-    open-pull-requests-limit: 0
-
-  # Maintain dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    versioning-strategy: increase-if-necessary
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 0
 
   # Maintain dependencies for Composer
+    ignore:
+      - dependency-name: "yiisoft/*"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions.
+
+  # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     open-pull-requests-limit: 0
 
   # Maintain dependencies for Composer
-    ignore:
-      - dependency-name: "yiisoft/*"
   - package-ecosystem: "composer"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions.
-  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n  - package-ecosystem: "composer"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "yiisoft/*"
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,8 @@
 version: 2
 updates:
-  # Maintain dependencies for Composer
-    ignore:
-      - dependency-name: "yiisoft/*"
-  - package-ecosystem: "composer"
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"\n    directory: "/"\n    schedule:\n      interval: "weekly"\n    cooldown:\n      default-days: 7\n    ignore:\n      - dependency-name: "yiisoft/*"\n  - package-ecosystem: "composer"
     directory: "/"
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
-    ignore:
-      - dependency-name: "yiisoft/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -27,7 +27,7 @@ permissions:
   contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -23,9 +23,11 @@ on:
 
 name: backwards compatibility
 
+permissions:
+  contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@master
+    uses: yiisoft/actions/.github/workflows/bc.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   phpunit:
-    uses: yiisoft/actions/.github/workflows/phpunit.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/phpunit.yml@master
     secrets:
       codecovToken: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,11 @@ on:
 
 name: build
 
+permissions:
+  contents: read
 jobs:
   phpunit:
-    uses: yiisoft/actions/.github/workflows/phpunit.yml@master
+    uses: yiisoft/actions/.github/workflows/phpunit.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     secrets:
       codecovToken: ${{ secrets.CODECOV_TOKEN }}
     with:

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -24,9 +24,11 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/infection.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,9 +20,11 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/infection.yml@master
+    uses: yiisoft/actions/.github/workflows/infection.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,8 +20,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -20,8 +20,5 @@ concurrency:
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
-    secrets:
-      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
-      repository: ${{ github.event.pull_request.head.repo.full_name }}
       php: '8.1'

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -1,7 +1,7 @@
 name: Rector + PHP CS Fixer
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'src/**'
       - 'tests/**'
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     secrets:
       token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:

--- a/.github/workflows/rector-cs.yml
+++ b/.github/workflows/rector-cs.yml
@@ -19,6 +19,6 @@ concurrency:
 
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector-cs.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/rector-cs.yml@master
     with:
       php: '8.1'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,9 +22,11 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@ab62d6b3b0e0cff6c9724ec5a395bedb41c639a2
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,8 @@ on:
       - '.github/**.yaml'
 
 permissions:
-  actions: read
-  contents: read
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+    pull_request:
+        paths:
+            - '.github/**.yml'
+            - '.github/**.yaml'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    zizmor:
+        name: Run zizmor 🌈
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
+                  annotations: true
+                  persona: 'pedantic'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "yiisoft/*": any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "yiisoft/*": any


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating service image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check